### PR TITLE
chore🔧: 使用 mobile-forever 提升桌面端可访问性

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.0.0",
     "less": "^4.1.3",
-    "postcss-px-to-viewport": "^1.1.1",
+    "postcss-mobile-forever": "^3.4.2",
     "unplugin-vue-components": "^0.24.1",
     "vite": "^4.1.4"
   }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,10 +1,20 @@
 module.exports = {
   plugins: {
-    'postcss-px-to-viewport': {
+    'postcss-mobile-forever': {
+      // 根元素，用于宽屏中令视图居中于屏幕
+      rootSelector: "body",
       // 设计稿的视口宽度
       viewportWidth: 375,
+      // 视图的最大宽度
+      maxDisplayWidth: 560,
+      // 禁止生成横屏媒体查询样式
+      disableLandscape: true,
+      // 禁止生成桌面端媒体查询样式
+      disableDesktop: true,
       // 需要忽略的css选择器
-      selectorBlackList: ["favor"]
-    },
+      selectorBlackList: ["favor"],
+      // 包含块是根元素的选择器
+      rootContainingBlockSelectorList: ["van-tabbar", "van-popup--bottom"],
+    }
   },
 };


### PR DESCRIPTION
哈喽 sakurafall，我给你的旅游住宿应用加上了我最近开发的 [postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever)，这个插件可以替代 postcss-px-to-viewport，同时解决了使用 px-to-viewport 之后，在大屏会出现大字的问题，mobile-forever 可以让移动端视图的屏幕在桌面端也正常访问。

如果您需要的话，欢迎合并这个 PR，我已经帮你改好了，下面是改完之后的效果截图，这些都是桌面端的展示效果：

<table>
	<tr>
		<td><img src="https://github.com/sakurafall/KITE-TRIP/assets/26893092/740acb48-1a03-4cb0-8b57-238203fcdd6b" alt="主页的桌面端效果" /></td>
		<td><img src="https://github.com/sakurafall/KITE-TRIP/assets/26893092/343a48e5-b48c-4ba2-8135-1540e4e6e1e6" alt="日期页面的桌面端效果" /></td>
	</tr>
	<tr>
		<td><img src="https://github.com/sakurafall/KITE-TRIP/assets/26893092/83d0a7ae-04e6-4c42-bff5-2ff925c86e3c" alt="城市页面的桌面端效果" /></td>
		<td><img src="https://github.com/sakurafall/KITE-TRIP/assets/26893092/4174ea48-dbc6-462a-ae2d-c28035949935" alt="旅馆页面的桌面端效果" /></td>
	</tr>
</table>
